### PR TITLE
Plug a hole in package object invalidation

### DIFF
--- a/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
+++ b/internal/zinc-core/src/main/scala/sbt/internal/inc/IncrementalNameHashing.scala
@@ -44,9 +44,16 @@ private[inc] class IncrementalNameHashingCommon(
       apis: APIs
   ): Set[String] = {
     val findSubclasses = relations.inheritance.internal.reverse _
+    val invalidatedClassesAndCodefinedClasses = for {
+      cls <- invalidatedClasses.iterator
+      file <- relations.definesClass(cls).iterator
+      cls1 <- relations.classNames(file)
+    } yield cls1
+
     debug("Invalidate package objects by inheritance only...")
     val invalidatedPackageObjects =
-      transitiveDeps(invalidatedClasses, log)(findSubclasses).filter(_.endsWith(".package"))
+      transitiveDeps(invalidatedClasses.toSet, log)(findSubclasses)
+        .filter(_.endsWith(".package"))
     debug(s"Package object invalidations: ${invalidatedPackageObjects.mkString(", ")}")
     invalidatedPackageObjects
   }

--- a/zinc/src/sbt-test/source-dependencies/package-object-name-inner/A.scala
+++ b/zinc/src/sbt-test/source-dependencies/package-object-name-inner/A.scala
@@ -1,0 +1,7 @@
+package b
+
+class A {
+  class Inner {
+    O.o
+  }
+}

--- a/zinc/src/sbt-test/source-dependencies/package-object-name-inner/O.scala
+++ b/zinc/src/sbt-test/source-dependencies/package-object-name-inner/O.scala
@@ -1,0 +1,5 @@
+package b
+
+object O {
+  def o = ""
+}

--- a/zinc/src/sbt-test/source-dependencies/package-object-name-inner/b.scala
+++ b/zinc/src/sbt-test/source-dependencies/package-object-name-inner/b.scala
@@ -1,0 +1,1 @@
+package object b extends A

--- a/zinc/src/sbt-test/source-dependencies/package-object-name-inner/changes/O1.scala
+++ b/zinc/src/sbt-test/source-dependencies/package-object-name-inner/changes/O1.scala
@@ -1,0 +1,5 @@
+package b
+
+object O {
+  def o = 42
+}

--- a/zinc/src/sbt-test/source-dependencies/package-object-name-inner/test
+++ b/zinc/src/sbt-test/source-dependencies/package-object-name-inner/test
@@ -1,0 +1,4 @@
+> compile
+$ copy-file changes/O1.scala O.scala
+> compile
+> checkIterations 3


### PR DESCRIPTION
If the package object inherits from a class that is not
directly invalidated but contains a member class that _is_
invalidated, Zinc should invalidate the package object.
Otherwise, scalac can't handle the case where package.class
but the classfile for its ancestor is deleted.

Tested manually, works: https://github.com/retronym/zinc-bug-implicit-in-package-object-parent/pull/2/files

TODO:
  - [ ] Scripted test.