### PR TITLE
Store UseScope set in a bitmask avoiding ArrayList overhead in Java protobuf binding

### DIFF
--- a/internal/zinc-persist-core/src/main/protobuf/schema.proto
+++ b/internal/zinc-persist-core/src/main/protobuf/schema.proto
@@ -403,7 +403,8 @@ message APIs {
 
 message UsedName {
     string name = 1;
-    repeated UseScope scopes = 2;
+    repeated UseScope scopes_deprecated = 2;
+    int32 scopes = 3;
 }
 
 /** Defines a container for the values of maps. */

--- a/internal/zinc-persist-core/src/main/protobuf/schema.proto
+++ b/internal/zinc-persist-core/src/main/protobuf/schema.proto
@@ -403,8 +403,7 @@ message APIs {
 
 message UsedName {
     string name = 1;
-    repeated UseScope scopes_deprecated = 2;
-    int32 scopes = 3;
+    repeated UseScope scopes = 2;
 }
 
 /** Defines a container for the values of maps. */
@@ -414,6 +413,7 @@ message Values {
 
 message UsedNames {
     repeated UsedName usedNames = 1;
+    repeated string default = 2;
 }
 
 message ClassDependencies {

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/BinaryAnalysisFormat.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/BinaryAnalysisFormat.scala
@@ -20,7 +20,7 @@ import xsbti.compile.{ CompileAnalysis, MiniSetup }
 final class BinaryAnalysisFormat(mappers: ReadWriteMappers) {
   private final val CurrentVersion = Schema.Version.V1_1
   private final val protobufWriters = new ProtobufWriters(mappers.getWriteMapper)
-  private final val protobufReaders = new ProtobufReaders(mappers.getReadMapper, CurrentVersion)
+  private final def protobufReaders() = new ProtobufReaders(mappers.getReadMapper, CurrentVersion)
 
   def write(writer: CodedOutputStream, analysis0: CompileAnalysis, miniSetup: MiniSetup): Unit = {
     val analysis = analysis0 match { case analysis: Analysis => analysis }
@@ -43,7 +43,7 @@ final class BinaryAnalysisFormat(mappers: ReadWriteMappers) {
 
   def read(reader: CodedInputStream): (CompileAnalysis, MiniSetup) = {
     val protobufFile = Schema.AnalysisFile.parseFrom(reader)
-    val (analysis, miniSetup, _) = protobufReaders.fromAnalysisFile(protobufFile)
+    val (analysis, miniSetup, _) = protobufReaders().fromAnalysisFile(protobufFile)
     analysis -> miniSetup
   }
 
@@ -54,7 +54,7 @@ final class BinaryAnalysisFormat(mappers: ReadWriteMappers) {
   ): CompileAnalysis = {
     val analysis = analysis0 match { case analysis: Analysis => analysis }
     val protobufAPIsFile = Schema.APIsFile.parseFrom(reader)
-    val (apis, _) = protobufReaders.fromApisFile(protobufAPIsFile, shouldStoreApis)
+    val (apis, _) = protobufReaders().fromApisFile(protobufAPIsFile, shouldStoreApis)
     analysis.copy(apis = apis)
   }
 }

--- a/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
+++ b/internal/zinc-persist/src/main/scala/sbt/internal/inc/binary/converters/ProtobufWriters.scala
@@ -649,7 +649,11 @@ final class ProtobufWriters(mapper: WriteMapper) {
       val builder = Schema.UsedName.newBuilder
         .setName(name)
       val it = usedName.scopes.iterator
-      while (it.hasNext) builder.addScopes(toUseScope(it.next))
+      var scopeBitMask = 0
+      while (it.hasNext) {
+        scopeBitMask |= (1 << toUseScope(it.next).getNumber)
+      }
+      builder.setScopes(scopeBitMask)
       builder.build
     }
 

--- a/internal/zinc-persist/src/test/scala/sbt/inc/binary/Scratch.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/binary/Scratch.scala
@@ -1,6 +1,6 @@
 package sbt.inc.binary
 
-import sbt.internal.inc.FileAnalysisStore
+import sbt.internal.inc.{ ConcreteAnalysisContents, FileAnalysisStore }
 import xsbti.compile.AnalysisContents
 
 import java.io.File
@@ -32,7 +32,11 @@ object Scratch {
   def migrate(analysis: AnalysisContents): AnalysisContents = {
     val tmp = File.createTempFile("analysis", ".bin")
     try {
-      FileAnalysisStore.binary(tmp).set(analysis)
+      FileAnalysisStore
+        .binary(tmp)
+        .set(
+          ConcreteAnalysisContents(analysis.getAnalysis, analysis.getMiniSetup.withStoreApis(false))
+        )
       FileAnalysisStore.binary(tmp).get().get
     } finally {
       tmp.delete()

--- a/internal/zinc-persist/src/test/scala/sbt/inc/binary/Scratch.scala
+++ b/internal/zinc-persist/src/test/scala/sbt/inc/binary/Scratch.scala
@@ -1,0 +1,42 @@
+package sbt.inc.binary
+
+import sbt.internal.inc.FileAnalysisStore
+import xsbti.compile.AnalysisContents
+
+import java.io.File
+
+object Scratch {
+  def main(args: Array[String]): Unit = {
+    val files = List(
+      "/Users/jz/code/scala/target/partest/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/scaladoc/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/replFrontend/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/reflect/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/repl/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/library/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/testkit/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/scalap/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/interactive/zinc/inc_compile.zip",
+      "/Users/jz/code/scala/target/compiler/zinc/inc_compile.zip"
+    )
+    val analysisList =
+      files.map(f => migrate(load(f)).getAnalysis)
+    println("Loaded all analysis files")
+    while (true) {
+      Thread.sleep(1000) // run: jcmd $PID GC.heap_dump /tmp/dump.hprof and open with IntelliJ or another tool
+    }
+  }
+  def load(f: String): AnalysisContents = {
+    FileAnalysisStore.binary(new File(f)).get().get()
+  }
+  def migrate(analysis: AnalysisContents): AnalysisContents = {
+    val tmp = File.createTempFile("analysis", ".bin")
+    try {
+      FileAnalysisStore.binary(tmp).set(analysis)
+      FileAnalysisStore.binary(tmp).get().get
+    } finally {
+      tmp.delete()
+      ()
+    }
+  }
+}


### PR DESCRIPTION
Reduces footprint for the test from 235,342,817 to 188,425,634 bytes (20% reduction)

