### PR TITLE
Review: classfile-java-api-phase3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,11 @@ jobs:
         cache: sbt
     - name: Setup SBT
       uses: sbt/setup-sbt@6bec67c98f542b9e17369bfca0ec822ac1363194 # v1.1.19
+    # Every sbt invocation runs with `--server` (a foreground JVM that runs the commands and exits)
+    # plus `-Dsbt.server.autostart=false` (never start or reuse a background server). Each `sbt` call
+    # is therefore a self-contained process with no shared state — important for the jobs below that
+    # invoke sbt twice (e.g. benchmarking the PR branch then the base branch), where a reused server
+    # could otherwise carry over stale classes or -D properties between invocations.
     - name: Build and test (1)
       if: ${{ matrix.jobtype == 1 }}
       shell: bash
@@ -62,7 +67,7 @@ jobs:
       if: ${{ matrix.jobtype == 2 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 -Dsbt.supershell=never "Test/compile" "crossTestBridges" "zincRoot/test" "scripted"
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 -Dsbt.supershell=never "Test/compile" "crossTestBridges" "zincRoot/test" "scripted"
     # Run the scripted suite with the classfile-based Java API path forced on, so the same
     # incremental scenarios are exercised in both modes (jobtype 1/2 cover the default reflection
     # path). See CONTRIBUTING.md "Running scripted tests in the classfile Java API mode".
@@ -70,28 +75,28 @@ jobs:
       if: ${{ matrix.jobtype == 7 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 -Dsbt.supershell=never -Dzinc.scripted.classfileJavaApi=true -Dzinc.classfileJavaApi.strict=true "Test/compile" "crossTestBridges" "scripted"
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 -Dsbt.supershell=never -Dzinc.scripted.classfileJavaApi=true -Dzinc.classfileJavaApi.strict=true "Test/compile" "crossTestBridges" "scripted"
     - name: Build and test (3)
       if: ${{ matrix.jobtype == 3 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 scalafmtCheckAll scalafmtSbtCheck headerCheck "Test/headerCheck" generateContrabands
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 scalafmtCheckAll scalafmtSbtCheck headerCheck "Test/headerCheck" generateContrabands
         git diff --exit-code
     - name: Benchmark (Scalac) (4)
       if: ${{ matrix.jobtype == 4 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Scalac.*" "runBenchmarks"
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Scalac.*" "runBenchmarks"
     - name: Benchmark (Shapeless) (5)
       if: ${{ matrix.jobtype == 5 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "runBenchmarks"
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "runBenchmarks"
     - name: Benchmark (AnalysisFormatBenchmark) (6)
       if: ${{ matrix.jobtype == 6 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*AnalysisFormatBenchmark.*" "runBenchmarks"
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*AnalysisFormatBenchmark.*" "runBenchmarks"
     - name: Checkout Target Branch (4-6)
       if: ${{ github.event_name == 'pull_request' && (matrix.jobtype >= 4 && matrix.jobtype <= 6) }}
       uses: actions/checkout@v6
@@ -101,14 +106,14 @@ jobs:
       if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 4 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Scalac.*" "runBenchmarks"
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Scalac.*" "runBenchmarks"
     - name: Benchmark (Shapeless) against Target Branch (5)
       if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 5 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "runBenchmarks"
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*Shapeless.*" "runBenchmarks"
     - name: Benchmark (AnalysisFormatBenchmark) against Target Branch (6)
       if: ${{ github.event_name == 'pull_request' && matrix.jobtype == 6 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*AnalysisFormatBenchmark.*" "runBenchmarks"
+        sbt -v --server -Dsbt.server.autostart=false -Dfile.encoding=UTF-8 "-Dbenchmark.pattern=.*AnalysisFormatBenchmark.*" "runBenchmarks"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,10 @@ jobs:
             java: 21
             distribution: temurin
             jobtype: 6
+          - os: ubuntu-latest
+            java: 21
+            distribution: temurin
+            jobtype: 7
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
@@ -59,6 +63,14 @@ jobs:
       shell: bash
       run: |
         sbt -v --server -Dfile.encoding=UTF-8 -Dsbt.supershell=never "Test/compile" "crossTestBridges" "zincRoot/test" "scripted"
+    # Run the scripted suite with the classfile-based Java API path forced on, so the same
+    # incremental scenarios are exercised in both modes (jobtype 1/2 cover the default reflection
+    # path). See CONTRIBUTING.md "Running scripted tests in the classfile Java API mode".
+    - name: Scripted (classfile Java API) (7)
+      if: ${{ matrix.jobtype == 7 }}
+      shell: bash
+      run: |
+        sbt -v --server -Dfile.encoding=UTF-8 -Dsbt.supershell=never -Dzinc.scripted.classfileJavaApi=true "Test/compile" "crossTestBridges" "scripted"
     - name: Build and test (3)
       if: ${{ matrix.jobtype == 3 }}
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
       if: ${{ matrix.jobtype == 7 }}
       shell: bash
       run: |
-        sbt -v --server -Dfile.encoding=UTF-8 -Dsbt.supershell=never -Dzinc.scripted.classfileJavaApi=true "Test/compile" "crossTestBridges" "scripted"
+        sbt -v --server -Dfile.encoding=UTF-8 -Dsbt.supershell=never -Dzinc.scripted.classfileJavaApi=true -Dzinc.classfileJavaApi.strict=true "Test/compile" "crossTestBridges" "scripted"
     - name: Build and test (3)
       if: ${{ matrix.jobtype == 3 }}
       shell: bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -126,14 +126,30 @@ runner can force it on or off for the whole run via a system property, so the sa
 can be checked under both paths:
 
 ```
-$ sbt -Dzinc.scripted.classfileJavaApi=true  scripted   # classfile-based Java API path
-$ sbt -Dzinc.scripted.classfileJavaApi=false scripted   # reflection path (the default)
+$ sbt -Dzinc.scripted.classfileJavaApi=true -Dzinc.classfileJavaApi.strict=true scripted  # classfile path
+$ sbt -Dzinc.scripted.classfileJavaApi=false scripted                                      # reflection (default)
 ```
 
-Without the property, each test uses its own value (the default, unless its
-`incOptions.properties` overrides it). CI runs the suite both ways: the default jobs cover the
-reflection path, and a dedicated job (`jobtype: 7` in `.github/workflows/ci.yml`) re-runs
-`scripted` with `-Dzinc.scripted.classfileJavaApi=true`.
+Two properties are involved:
+
+- `-Dzinc.scripted.classfileJavaApi=true|false` forces `IncOptions.classfileJavaApi` for the whole
+  scripted run. Without it, each test uses its own value (the default, unless its
+  `incOptions.properties` overrides it).
+- `-Dzinc.classfileJavaApi.strict=true` makes a failure *inside* the classfile-based extractor
+  propagate instead of being logged and swallowed. In production that path is deliberately
+  best-effort (it must never fail a compile that would otherwise succeed), but under
+  `classfileApiOnly` it is the primary path for every Java class, so for testing we want a crash
+  there to fail the build. Pair it with the property above when running the matrix.
+
+CI runs the suite both ways: the default jobs cover the reflection path, and a dedicated job
+(`jobtype: 7` in `.github/workflows/ci.yml`) re-runs `scripted` with both properties set.
+
+Note: the scripted suite is good at catching *crashes and structural breakage* in the classfile
+path, but it is largely insensitive to *fine-grained* Java API-hash regressions (e.g. a dropped
+method return type) because cross-unit invalidation there is dominated by source changes and
+inheritance edges. That fine-grained correctness is pinned by the unit tests in `zinc-apiinfo`
+(`ClassfileToAPISpecification`, `DifferentialApiSpecification`, `FBoundStressSpecification`) and by
+`IncrementalCompilerSpec`'s classfileJavaApi-vs-reflection invalidation check.
 
 ### Reaching out for help
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,6 +107,34 @@ benchmarks and include them in *both* the commit message and PR description.
 The richer the descriptions the better. If you're not changing the compiler
 bridge, you don't need to run these benchmarks.
 
+### Running scripted tests
+
+Zinc's integration tests live in `zinc/src/sbt-test` and are run with the `scripted` sbt
+task, which replays each `test`/`pending` script against a real incremental compile:
+
+```
+$ sbt scripted                                   # the whole suite
+$ sbt "scripted source-dependencies/*"           # one group
+$ sbt "scripted source-dependencies/java-basic"  # a single test
+```
+
+#### Running scripted tests in the classfile Java API mode
+
+`IncOptions.classfileJavaApi` makes Zinc extract each Java class's API from its class file
+instead of by reflectively loading it (sbt/zinc#837). It is off by default. The scripted
+runner can force it on or off for the whole run via a system property, so the same scenarios
+can be checked under both paths:
+
+```
+$ sbt -Dzinc.scripted.classfileJavaApi=true  scripted   # classfile-based Java API path
+$ sbt -Dzinc.scripted.classfileJavaApi=false scripted   # reflection path (the default)
+```
+
+Without the property, each test uses its own value (the default, unless its
+`incOptions.properties` overrides it). CI runs the suite both ways: the default jobs cover the
+reflection path, and a dedicated job (`jobtype: 7` in `.github/workflows/ci.yml`) re-runs
+`scripted` with `-Dzinc.scripted.classfileJavaApi=true`.
+
 ### Reaching out for help
 
 If you need any help, consider opening a draft pull request and asking

--- a/bin/run-ci.sh
+++ b/bin/run-ci.sh
@@ -2,10 +2,13 @@
 set -eu
 set -o nounset
 
+# --server runs sbt in the foreground (one JVM, runs the commands, exits); autostart=false ensures
+# no background sbt server is started or reused, so this invocation shares no state with any other.
 sbt -Dfile.encoding=UTF-8 \
   -J-XX:ReservedCodeCacheSize=512M \
   -J-Xms1024M -J-Xmx2048M -J-server \
   --server \
+  -Dsbt.server.autostart=false \
   scalafmtCheckAll \
   scalafmtSbtCheck \
   Test/compile \

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -188,19 +188,13 @@ object ClassfileToAPI {
 
     val classSigStr = cf.attributes.find(_.isSignature).map(cf.stringValue)
     val classSig = classSigStr.flatMap(SignatureParser.classSignature)
-    val (typeParams, parents): (Array[api.TypeParameter], Array[api.Type]) = classSig match {
-      case Some(cs) =>
-        (
-          cs.typeParams.map(toTypeParam).toArray,
-          (cs.superclass +: cs.interfaces).map(toType).toArray
-        )
-      case None =>
-        val erased = (cf.superClassName +: cf.interfaceNames.toIndexedSeq)
-          .filter(_.nonEmpty)
-          .map(ClassToAPI.reference)
-          .toArray
-        (noTypeParameters, erased)
-    }
+    val typeParams: Array[api.TypeParameter] =
+      classSig.map(_.typeParams.map(toTypeParam).toArray).getOrElse(noTypeParameters)
+    // Parents are the *transitive* supertype closure (matching ClassToAPI.allSuperTypes), resolved
+    // through parent classfiles — not just the direct supertypes. Otherwise a subtyping relationship
+    // this class holds only through an intermediate (e.g. a member-less marker interface that a
+    // superclass stops implementing) would not change its API, under-invalidating its dependents.
+    val parents: Array[api.Type] = collectParents(cf, resolveParent)
 
     val classAnnots = syntheticAnnotations(
       "signature" -> rawSignature(classSigStr),
@@ -460,6 +454,53 @@ object ClassfileToAPI {
     }
     (instance.toArray, static.toArray)
   }
+
+  /**
+   * The transitive supertype closure as api type references, resolved through parent classfiles
+   * (byte-only, no class loading) — the classfile analogue of [[ClassToAPI.allSuperTypes]]. Direct
+   * supertypes keep their generic form from the `Signature` attribute; ancestors are followed via
+   * their erased (`$`-joined) binary names. Cycle-safe (a visited set keyed on the erased name) and
+   * fail-soft (an unresolved parent just ends that branch). `java.lang.Object` is included for a
+   * class but not for an interface, matching reflection (an interface's `getGenericSuperclass` is
+   * null). The class itself is excluded.
+   */
+  private def collectParents(
+      cf: ClassFile,
+      resolveParent: String => Option[ClassFile]
+  ): Array[api.Type] = {
+    // (erased binary name, reference) for each direct supertype of `c` — generic when a Signature is
+    // present, erased otherwise; Object dropped for interfaces (via superTypeNames' class/iface split).
+    def directSupers(c: ClassFile): Seq[(String, api.Type)] = {
+      val isIface = Modifier.isInterface(c.accessFlags)
+      c.attributes
+        .find(_.isSignature)
+        .map(c.stringValue)
+        .flatMap(SignatureParser.classSignature) match {
+        case Some(cs) =>
+          val supers = if (isIface) cs.interfaces else cs.superclass +: cs.interfaces
+          supers.collect { case s: SigClass => erasedSigClassName(s) -> toType(s) }
+        case None =>
+          superTypeNames(c).map(n => n -> ClassToAPI.reference(n))
+      }
+    }
+    val out = ArrayBuffer.empty[api.Type]
+    val visited = scala.collection.mutable.Set(cf.className) // exclude self
+    val queue = scala.collection.mutable.Queue.empty[(String, api.Type)]
+    queue ++= directSupers(cf)
+    while (queue.nonEmpty) {
+      val (name, ref) = queue.dequeue()
+      if (visited.add(name)) {
+        out += ref
+        resolveParent(name).foreach(pcf => queue ++= directSupers(pcf))
+      }
+    }
+    out.toArray
+  }
+
+  // The erased ($-joined) binary name of a class-type signature, matching cf.superClassName /
+  // interfaceNames (e.g. `pkg.Outer<String>.Inner` -> "pkg.Outer$Inner").
+  private def erasedSigClassName(s: SigClass): String =
+    (s.name +: s.inners.map(_.name)).mkString("$")
 
   private val ObjectRef = ClassToAPI.reference("java.lang.Object")
 

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -92,39 +92,69 @@ object ClassfileToAPI {
         } catch { case NonFatal(_) => Nil }
     }
 
+  // Decodes one `annotation` structure (JVMS 4.7.16) from `in` into a `type(name=value,...)` string,
+  // capturing element values too (so `@A("a")` differs from `@A("b")`). Length-prefixes each composed
+  // value so concatenation can't collide (e.g. {"a,b","c"} vs {"a","b,c"}); we only need distinct,
+  // deterministic strings for hashing, not parseability.
+  private def decodeAnnotation(in: DataInputStream, cf: ClassFile): String = {
+    def poolStr(i: Int): String = cf.constantPool(i).value.fold("")(_.toString)
+    def lp(s: String): String = s.length.toString + ":" + s
+    def elementValue(): String =
+      in.readUnsignedByte().toChar match {
+        case 'e' => poolStr(in.readUnsignedShort()) + "." + poolStr(in.readUnsignedShort())
+        case 'c' => poolStr(in.readUnsignedShort())
+        case '@' => annotationString()
+        case '[' =>
+          val n = in.readUnsignedShort()
+          (0 until n).map(_ => lp(elementValue())).mkString("[", "", "]")
+        case _ => poolStr(in.readUnsignedShort())
+      }
+    def annotationString(): String = {
+      val tpe = poolStr(in.readUnsignedShort()).stripPrefix("L").stripSuffix(";").replace('/', '.')
+      val pairs = in.readUnsignedShort()
+      val args =
+        (0 until pairs).map(_ => lp(poolStr(in.readUnsignedShort()) + "=" + elementValue()))
+      if (args.isEmpty) tpe else args.mkString(tpe + "(", "", ")")
+    }
+    annotationString()
+  }
+
   /**
    * Declared annotations rendered as `type(name=value,...)` strings, from RuntimeVisible/Invisible
-   * attributes (JVMS 4.7.16) — capturing element values too, so `@A("a")` differs from `@A("b")`.
+   * attributes (JVMS 4.7.16).
    */
   private def annotationStrings(cf: ClassFile, attrs: Seq[AttributeInfo]): Seq[String] = {
     val out = ArrayBuffer.empty[String]
     for (a <- attrs if a.isRuntimeVisibleAnnotations || a.isRuntimeInvisibleAnnotations) {
       try {
         val in = new DataInputStream(new ByteArrayInputStream(a.value))
-        def poolStr(i: Int): String = cf.constantPool(i).value.fold("")(_.toString)
-        // Length-prefix each composed value so concatenation can't collide (e.g. {"a,b","c"} vs
-        // {"a","b,c"}); we only need distinct, deterministic strings for hashing, not parseability.
-        def lp(s: String): String = s.length.toString + ":" + s
-        def elementValue(): String =
-          in.readUnsignedByte().toChar match {
-            case 'e' => poolStr(in.readUnsignedShort()) + "." + poolStr(in.readUnsignedShort())
-            case 'c' => poolStr(in.readUnsignedShort())
-            case '@' => annotationString()
-            case '[' =>
-              val n = in.readUnsignedShort()
-              (0 until n).map(_ => lp(elementValue())).mkString("[", "", "]")
-            case _ => poolStr(in.readUnsignedShort())
-          }
-        def annotationString(): String = {
-          val tpe =
-            poolStr(in.readUnsignedShort()).stripPrefix("L").stripSuffix(";").replace('/', '.')
-          val pairs = in.readUnsignedShort()
-          val args =
-            (0 until pairs).map(_ => lp(poolStr(in.readUnsignedShort()) + "=" + elementValue()))
-          if (args.isEmpty) tpe else args.mkString(tpe + "(", "", ")")
-        }
         val num = in.readUnsignedShort()
-        (0 until num).foreach(_ => out += annotationString())
+        (0 until num).foreach(_ => out += decodeAnnotation(in, cf))
+      } catch { case NonFatal(_) => () }
+    }
+    out.toSeq
+  }
+
+  /**
+   * Parameter annotations rendered as `index:type(...)` strings, from RuntimeVisible/Invisible
+   * ParameterAnnotations attributes (JVMS 4.7.18–19). Position-prefixed so moving an annotation
+   * between parameters is a change. ClassToAPI carries these on the parameter type (api.Annotated);
+   * folding them into the method's synthetic annotation is enough to track changes for hashing.
+   */
+  private def parameterAnnotationStrings(cf: ClassFile, attrs: Seq[AttributeInfo]): Seq[String] = {
+    val out = ArrayBuffer.empty[String]
+    for (
+      a <- attrs
+      if a.isNamed("RuntimeVisibleParameterAnnotations") ||
+        a.isNamed("RuntimeInvisibleParameterAnnotations")
+    ) {
+      try {
+        val in = new DataInputStream(new ByteArrayInputStream(a.value))
+        val numParams = in.readUnsignedByte()
+        (0 until numParams).foreach { p =>
+          val n = in.readUnsignedShort()
+          (0 until n).foreach(_ => out += s"$p:" + decodeAnnotation(in, cf))
+        }
       } catch { case NonFatal(_) => () }
     }
     out.toSeq
@@ -147,7 +177,7 @@ object ClassfileToAPI {
     val mainClasses = ArrayBuffer.empty[String]
     for ((name, cf) <- named) {
       classApis ++= classLikes(name, cf, cachedResolve)
-      if (cf.methods.exists(_.isMain)) mainClasses += name
+      if (hasMain(cf, cachedResolve)) mainClasses += name
     }
     (classApis.toSeq, mainClasses.toSeq)
   }
@@ -314,7 +344,8 @@ object ClassfileToAPI {
     val annots = syntheticAnnotations(
       "signature" -> rawSignature(sigStr),
       "throws" -> exceptionNames(cf, m.attributes),
-      "annotations" -> annotationStrings(cf, m.attributes)
+      "annotations" -> annotationStrings(cf, m.attributes),
+      "paramAnnotations" -> parameterAnnotationStrings(cf, m.attributes)
     )
     val d = api.Def.of(name, acc, mods, annots, typeParams, Array(paramList), returnType)
     (m.isStatic, d)
@@ -501,6 +532,29 @@ object ClassfileToAPI {
   // interfaceNames (e.g. `pkg.Outer<String>.Inner` -> "pkg.Outer$Inner").
   private def erasedSigClassName(s: SigClass): String =
     (s.name +: s.inners.map(_.name)).mkString("$")
+
+  /**
+   * Whether the class has a `main` method — its own or one inherited from a superclass — mirroring
+   * ClassToAPI's use of `getMethods` (which includes inherited methods). The superclass chain is
+   * walked via parent classfiles; a static method declared on an interface is not inherited (matching
+   * getMethods and [[collectInherited]]), so it never counts. Cycle-safe and fail-soft.
+   */
+  private def hasMain(cf: ClassFile, resolveParent: String => Option[ClassFile]): Boolean =
+    cf.methods.exists(_.isMain) || {
+      val visited = scala.collection.mutable.Set(cf.className)
+      val queue = scala.collection.mutable.Queue.empty[String]
+      queue ++= superTypeNames(cf)
+      var found = false
+      while (!found && queue.nonEmpty) {
+        val n = queue.dequeue()
+        if (visited.add(n)) resolveParent(n).foreach { pcf =>
+          val isIface = Modifier.isInterface(pcf.accessFlags)
+          if (pcf.methods.exists(m => m.isMain && !isIface)) found = true
+          else queue ++= superTypeNames(pcf)
+        }
+      }
+      found
+    }
 
   private val ObjectRef = ClassToAPI.reference("java.lang.Object")
 

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -47,6 +47,16 @@ import sbt.util.Logger
  * API byte-for-byte (e.g. type-variable names are unqualified, and wildcards keep only their bound);
  * it only needs to be deterministic and to change when the class's public shape changes. See
  * docs/design/classfile-based-java-api.md.
+ *
+ * Two differences from [[ClassToAPI]] are intentional and do not under-invalidate:
+ *   - Annotations are read from both the RuntimeVisible and RuntimeInvisible attributes, so
+ *     CLASS-retention annotations are captured here even though reflection's `getAnnotations` (which
+ *     sees only RUNTIME retention) would miss them. This is strictly more conservative — it can only
+ *     add hash sensitivity, never remove it.
+ *   - A member class referenced in its *outer's* declared members ([[nestedClassDefs]]) carries no
+ *     type parameters or annotations, whereas reflection's reference does. The member class's own
+ *     `ClassLike` entry models them in full, so a change there still invalidates its dependents; only
+ *     the outer's view of it is abbreviated.
  */
 object ClassfileToAPI {
   import api.DefinitionType.{ ClassDef, Module, Trait }

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -50,9 +50,16 @@ import sbt.util.Logger
  *
  * Two differences from [[ClassToAPI]] are intentional and do not under-invalidate:
  *   - Annotations are read from both the RuntimeVisible and RuntimeInvisible attributes, so
- *     CLASS-retention annotations are captured here even though reflection's `getAnnotations` (which
- *     sees only RUNTIME retention) would miss them. This is strictly more conservative — it can only
- *     add hash sensitivity, never remove it.
+ *     CLASS-retention annotations (the default when no `@Retention` is given) are captured here even
+ *     though reflection's `getAnnotations` does not see them. The relevant criterion for invalidation
+ *     is whether compiling a *dependent* against this classfile can observe the annotation, not
+ *     whether it survives to runtime: javac exposes RuntimeInvisible annotations through
+ *     `javax.lang.model` (`getAnnotationMirrors`), so an annotation processor introspecting this type
+ *     during a dependent's compilation can act on a CLASS-retained annotation and emit different
+ *     output. Reflection's omission is thus a limitation of its runtime-only lens, not a designed
+ *     semantic — capturing these here is closer to what a dependent compiler can actually see. (SOURCE
+ *     retention is absent from the classfile, so neither path sees it, correctly.) The cost is mild
+ *     over-invalidation: a CLASS-retained annotation that no processor reads still bumps the hash.
  *   - A member class referenced in its *outer's* declared members ([[nestedClassDefs]]) carries no
  *     type parameters or annotations, whereas reflection's reference does. The member class's own
  *     `ClassLike` entry models them in full, so a change there still invalidates its dependents; only

--- a/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
+++ b/internal/zinc-apiinfo/src/main/scala/sbt/internal/inc/ClassfileToAPI.scala
@@ -194,9 +194,11 @@ object ClassfileToAPI {
     val acc = ClassToAPI.access(cf.accessFlags, enclPkg)
     val isInterface = Modifier.isInterface(cf.accessFlags)
     val tpe = if (isInterface) Trait else ClassDef
-    // Top-level unless the classfile's InnerClasses attribute lists itself as a member of another.
-    val topLevel =
-      !cf.innerClasses.exists(i => i.innerClassName == cf.className && i.outerClassName.nonEmpty)
+    // Top-level unless the InnerClasses attribute has a self entry — present for member, local, and
+    // anonymous classes (JVMS 4.7.6 requires it for any non-package-member). Matches reflection's
+    // `getEnclosingClass == null`. Local/anonymous self entries have an empty outer (outer index 0),
+    // so the entry's presence — not its outer — is what marks the class as nested.
+    val topLevel = !cf.innerClasses.exists(_.innerClassName == cf.className)
 
     val fields = cf.fields.toIndexedSeq.map(fieldDef(cf, _, enclPkg))
     val methods = cf.methods.toIndexedSeq.collect {

--- a/internal/zinc-apiinfo/src/test/resources/fbound/FBoundedStress.java
+++ b/internal/zinc-apiinfo/src/test/resources/fbound/FBoundedStress.java
@@ -1,0 +1,378 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import java.io.Serializable;
+import java.util.*;
+import java.lang.annotation.*;
+
+// ---------------------------------------------------------------------------
+// Annotations used as metadata (stresses annotation-attribute parser)
+// ---------------------------------------------------------------------------
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@interface Stress {
+    Class<? extends Comparable<?>>[] comparators() default {};
+    Class<?>[] witnesses()                          default {};
+    String     note()                               default "";
+}
+
+// ---------------------------------------------------------------------------
+// 1. Deep single-parameter F-bound chain
+//    Each level adds one more layer to the Signature attribute.
+// ---------------------------------------------------------------------------
+
+interface L0<T extends L0<T>> {
+    T self();
+
+    // Signature cycle through method return types. `companion()` names Mirror,
+    // and Mirror.origin() names L0 again — so following method signatures without
+    // memoizing visited types loops forever:
+    //   L0.companion -> Mirror<T> -> Mirror.origin -> L0<T> -> L0.companion -> ...
+    Mirror<T> companion();
+
+    default int depth() { return 0; }
+}
+
+// The other half of the cycle: every method here references back to L0 (the
+// first/parent type of the chain), closing the loop a naive parser would chase.
+interface Mirror<T extends L0<T>> {
+    L0<T> origin();
+    T     pivot();
+}
+
+interface L1<T extends L1<T>> extends L0<T> {
+    @Override default int depth() { return 1; }
+}
+
+interface L2<T extends L2<T>> extends L1<T> {
+    @Override default int depth() { return 2; }
+}
+
+interface L3<T extends L3<T>> extends L2<T> {
+    @Override default int depth() { return 3; }
+}
+
+interface L4<T extends L4<T>> extends L3<T> {
+    @Override default int depth() { return 4; }
+}
+
+interface L5<T extends L5<T>> extends L4<T> {
+    @Override default int depth() { return 5; }
+}
+
+interface L6<T extends L6<T>> extends L5<T> {
+    @Override default int depth() { return 6; }
+}
+
+interface L7<T extends L7<T>> extends L6<T> {
+    @Override default int depth() { return 7; }
+}
+
+interface L8<T extends L8<T>> extends L7<T> {
+    @Override default int depth() { return 8; }
+}
+
+// Concrete leaf — produces a Signature like:
+//   Ljava/lang/Object;LL8<TLeaf;>;  (simplified)
+// plus bridge methods from every covariant self() override.
+@Stress(note = "deep single-param F-bound leaf")
+final class Leaf implements L8<Leaf> {
+    @Override public Leaf self() { return this; }
+
+    // Closes the L0 <-> Mirror signature cycle for the concrete leaf. The
+    // anonymous Mirror also adds another InnerClasses entry to chew on.
+    @Override public Mirror<Leaf> companion() {
+        return new Mirror<Leaf>() {
+            @Override public L0<Leaf> origin() { return Leaf.this; }
+            @Override public Leaf     pivot()  { return Leaf.this; }
+        };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Multi-parameter mutually-constrained F-bounds
+//    A <-> B mutual reference via a shared carrier interface.
+// ---------------------------------------------------------------------------
+
+interface Carrier<A extends Carrier<A, B>, B extends Carrier<B, A>> {
+    A left();
+    B right();
+}
+
+@Stress(note = "mutual F-bound left")
+final class LeftNode implements Carrier<LeftNode, RightNode> {
+    @Override public LeftNode  left()  { return this; }
+    @Override public RightNode right() { return new RightNode(); }
+}
+
+@Stress(note = "mutual F-bound right")
+final class RightNode implements Carrier<RightNode, LeftNode> {
+    @Override public RightNode left()  { return this; }
+    @Override public LeftNode  right() { return new LeftNode(); }
+}
+
+// ---------------------------------------------------------------------------
+// 2b. Mutually recursive type parameters across two type constructors.
+//     Type *variables* can't cycle directly (`<A extends B, B extends A>` is
+//     rejected), but they CAN be mutually recursive *through* generic types:
+//     each interface's parameters are bounded by the other interface, and each
+//     is additionally F-bounded on itself. The bound graph has a 2-cycle
+//     (Yin <-> Yang) that a naive bound-resolver must break.
+// ---------------------------------------------------------------------------
+
+interface Yin<Y extends Yin<Y, Z>, Z extends Yang<Z, Y>> {
+    Z yang();   // crosses to the other constructor
+    Y self();   // F-bound on this one
+}
+
+interface Yang<Z extends Yang<Z, Y>, Y extends Yin<Y, Z>> {
+    Y yin();
+    Z self();
+}
+
+@Stress(note = "mutually recursive type params (yin)")
+final class ConcYin implements Yin<ConcYin, ConcYang> {
+    @Override public ConcYang yang() { return new ConcYang(); }
+    @Override public ConcYin  self() { return this; }
+}
+
+@Stress(note = "mutually recursive type params (yang)")
+final class ConcYang implements Yang<ConcYang, ConcYin> {
+    @Override public ConcYin  yin()  { return new ConcYin(); }
+    @Override public ConcYang self() { return this; }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Wildcard capture inside F-bound + Comparable
+//    Signature explosion: <T:Ljava/lang/Comparable<-TT;>;>
+// ---------------------------------------------------------------------------
+
+@Stress(note = "wildcard in F-bound with Comparable")
+abstract class WildStress<T extends Comparable<? super T>>
+        implements Comparable<WildStress<T>> {
+
+    abstract T value();
+
+    @Override
+    public int compareTo(WildStress<T> other) {
+        return this.value().compareTo(other.value());
+    }
+
+    // Covariant return triggers a bridge method
+    abstract WildStress<T> copy();
+}
+
+final class WildInt extends WildStress<Integer> {
+    private final int v;
+    WildInt(int v) { this.v = v; }
+    @Override Integer value() { return v; }
+    @Override WildInt copy()  { return new WildInt(v); }  // bridge for WildStress.copy()
+}
+
+// ---------------------------------------------------------------------------
+// 4. Bridge-method proliferation via covariant overrides in a chain
+//    Each class overrides a method with a covariant return type, producing
+//    one synthetic bridge per level.
+// ---------------------------------------------------------------------------
+
+abstract class Base {
+    abstract Base produce();
+    Base consume(Base b) { return b; }
+}
+
+abstract class Mid extends Base {
+    @Override abstract Mid produce();   // bridge: Base produce()
+    @Override Mid consume(Base b) { return (Mid) b; }
+}
+
+abstract class Top extends Mid {
+    @Override abstract Top produce();   // bridge: Mid produce(), Base produce()
+    @Override Top consume(Base b) { return (Top) b; }
+}
+
+@Stress(note = "covariant bridge proliferation")
+final class Tip extends Top {
+    @Override public Tip produce() { return this; }  // 3 bridges total
+    @Override public Tip consume(Base b) { return (Tip) b; }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Raw-type / generic mixed inheritance
+//    SomeRaw extends a raw generic; javac emits unchecked-cast bridge logic.
+// ---------------------------------------------------------------------------
+
+abstract class GenericBase<T> {
+    abstract T get();
+    abstract void set(T value);
+}
+
+@SuppressWarnings({"rawtypes", "unchecked"})
+final class SomeRaw extends GenericBase {  // raw supertype
+    private Object val;
+    @Override public Object get()         { return val; }
+    @Override public void   set(Object v) { val = v; }
+}
+
+// ---------------------------------------------------------------------------
+// 6. Deeply nested generic inner classes
+//    Signature of the innermost class encodes all enclosing type parameters.
+// ---------------------------------------------------------------------------
+
+@Stress(note = "nested generic inner class signatures")
+class Outer<A> {
+    class Middle<B extends Comparable<B>> {
+        class Inner<C extends L4<C>> {
+            // Signature references A, B, C plus their bounds
+            Map<A, Map<B, List<C>>> combined() { return Collections.emptyMap(); }
+
+            // Stress: method return type references all three levels
+            Inner<C> innerSelf() { return this; }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 7. Default method diamond
+//    Both Left7 and Right7 provide a default; concrete class must override.
+//    Produces synthetic accessor / forwarder methods in the class file.
+// ---------------------------------------------------------------------------
+
+interface DiamondTop {
+    default String name() { return "top"; }
+}
+
+interface DiamondLeft extends DiamondTop {
+    @Override default String name() { return "left"; }
+}
+
+interface DiamondRight extends DiamondTop {
+    @Override default String name() { return "right"; }
+}
+
+@Stress(note = "diamond default method forwarders")
+final class DiamondBottom implements DiamondLeft, DiamondRight {
+    @Override public String name() { return DiamondLeft.super.name() + "+" + DiamondRight.super.name(); }
+}
+
+// ---------------------------------------------------------------------------
+// 8. Generic method with multiple independent F-bounds + throws clause
+//    Stresses method-descriptor and exception-table parsing together.
+// ---------------------------------------------------------------------------
+
+@Stress(
+    comparators = { String.class, Integer.class },
+    witnesses   = { Leaf.class, WildInt.class },
+    note        = "multi-bound generic method"
+)
+final class Utilities {
+
+    /**
+     * Mutually recursive type parameters within a single method signature:
+     * A is bounded by Comparable&lt;B&gt; and B by Comparable&lt;A&gt;. Legal because the
+     * recursion passes through Comparable rather than being a bare variable cycle.
+     * The method Signature attribute encodes both bounds referencing each other.
+     */
+    public static <A extends Comparable<B>, B extends Comparable<A>>
+    int mutualCompare(A a, B b) {
+        return a.compareTo(b) - b.compareTo(a);
+    }
+
+    /**
+     * A method whose type parameter has two independent upper bounds (produces &-separator
+     * in the Signature attribute) plus a checked exception.
+     */
+    public static <T extends L8<T> & Serializable & Comparable<T>>
+    T roundTrip(T value) throws CloneNotSupportedException {
+        // The cast here is legal but forces the verifier to check bridge compatibility.
+        @SuppressWarnings("unchecked")
+        T copy = (T) value;
+        return copy.self();
+    }
+
+    /**
+     * Wildcard hell: nested wildcards in both parameter and return position.
+     * Exercises signature parsing of `? extends List<? super T>`.
+     */
+    public static <T extends Comparable<? super T>>
+    List<? extends T> sortedCopy(Collection<? extends T> src) {
+        List<T> result = new ArrayList<>(src);
+        Collections.sort(result);
+        return result;
+    }
+
+    /**
+     * Higher-kinded simulation via a Function interface chain.
+     * The Signature on this method is notably long.
+     */
+    public static <A extends L4<A>, B extends WildStress<? extends Comparable<? super A>>>
+    Map<A, B> crossProduct(List<A> as, List<B> bs) {
+        Map<A, B> out = new LinkedHashMap<>();
+        for (A a : as) for (B b : bs) out.put(a, b);
+        return out;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 9. Enum with abstract method + generic interface
+//    Each enum constant becomes an anonymous class in the class file.
+//    Parsers iterating InnerClasses attributes will see all of them.
+// ---------------------------------------------------------------------------
+
+@Stress(note = "enum anonymous-class inner entries")
+enum Transformer implements L0<Transformer> {
+    IDENTITY {
+        @Override public <T> T apply(T x) { return x; }
+        @Override public Transformer self() { return IDENTITY; }
+    },
+    BOXED {
+        @Override public <T> T apply(T x) { return x; }  // simplified
+        @Override public Transformer self() { return BOXED; }
+    };
+
+    public abstract <T> T apply(T x);
+
+    // Shared (non-abstract) — satisfies L0.companion() for every enum constant
+    // and re-enters the L0 <-> Mirror signature cycle.
+    @Override public Mirror<Transformer> companion() {
+        return new Mirror<Transformer>() {
+            @Override public L0<Transformer> origin() { return Transformer.this; }
+            @Override public Transformer     pivot()  { return Transformer.this; }
+        };
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Main — just enough to force class loading and expose any parse errors.
+// ---------------------------------------------------------------------------
+
+public class FBoundedStress {
+    public static void main(String[] args) throws Exception {
+        // Force class initialization (also ensures the class files are all valid)
+        System.out.println("Leaf depth      : " + new Leaf().depth());
+        // Walk the L0 <-> Mirror signature cycle one full lap at runtime.
+        System.out.println("Cycle lap       : " + new Leaf().companion().origin().companion().pivot().depth());
+        System.out.println("Carrier mutual  : " + new LeftNode().right().left().getClass().getSimpleName());
+        System.out.println("Yin/Yang        : " + new ConcYin().yang().yin().getClass().getSimpleName());
+        System.out.println("mutualCompare   : " + Utilities.mutualCompare("a", "b"));
+        System.out.println("WildInt cmp     : " + new WildInt(1).compareTo(new WildInt(2)));
+        System.out.println("Tip produce     : " + new Tip().produce().getClass().getSimpleName());
+        System.out.println("Diamond name    : " + new DiamondBottom().name());
+        System.out.println("SomeRaw get     : " + ((java.util.function.Supplier<Object>) () -> { var r = new SomeRaw(); r.set("x"); return r.get(); }).get());
+        System.out.println("Utilities sort  : " + Utilities.sortedCopy(List.of(3, 1, 2)));
+        System.out.println("Transformer     : " + Transformer.IDENTITY.apply("ok"));
+
+        // Nested inner — exercises Outer<A>.Middle<B>.Inner<C> signatures
+        Outer<String>.Middle<Integer>.Inner<Leaf> inner =
+            new Outer<String>().new Middle<Integer>().new Inner<Leaf>();
+        System.out.println("Inner self      : " + (inner.innerSelf() == inner));
+    }
+}

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -240,4 +240,53 @@ class DifferentialApiSpecification extends UnitSpec {
       assert(r == c, s"inner-class ctor param count differs — reflect=$r classfile=$c")
     }
   }
+
+  // The simple (Projection) name of a parent type reference, e.g. "Marker"/"Object". ClassToAPI and
+  // ClassfileToAPI both build parent references via ClassToAPI.reference, which yields a Projection.
+  private def parentSimpleName(t: xsbti.api.Type): Option[String] = t match {
+    case p: xsbti.api.Projection    => Some(p.id)
+    case p: xsbti.api.Parameterized => parentSimpleName(p.baseType)
+    case _                          => None
+  }
+  private def parentNames(apis: Seq[ClassLike]): Set[String] =
+    apis.flatMap(_.structure.parents.toSeq.flatMap(parentSimpleName)).toSet
+
+  // KNOWN-BUG WITNESS (deviation #1): ClassToAPI lists the *transitive* supertype closure in a
+  // class's `parents` (ClassToAPI.allSuperTypes), whereas ClassfileToAPI lists only the *direct*
+  // supertypes (ClassfileToAPI.classLikes: superclass +: interfaces). So a subtyping relationship
+  // that `C` holds only through an intermediate `B` is invisible to the classfile path. With a
+  // member-less marker interface there is nothing for collectInherited to surface either, so C's
+  // classfile API — and thus its hash — does not change when B stops implementing the marker, even
+  // though C is no longer a Marker. Reflection's hash does change. This pins that gap empirically;
+  // once #1 is fixed (walk the transitive closure in classLikes), the two classfile hashes below
+  // will differ and this test should be updated to assert agreement with reflection.
+  it should "(known bug #1) miss a transitive-supertype change that reflection catches" in {
+    IO.withTemporaryDirectory { temp =>
+      // v1: C -> B -> Marker (C is transitively a Marker).  v2: B no longer implements Marker.
+      val v1 = "interface Marker {} class B implements Marker {} public class C extends B {}"
+      val v2 = "interface Marker {} class B {} public class C extends B {}"
+      val (reflect1, classfile1) = buildApis(temp, 100, "C", v1)
+      val (reflect2, classfile2) = buildApis(temp, 101, "C", v2)
+
+      // Structural witness: reflection's parents for C include the transitive Marker; classfile's
+      // direct-only parents do not.
+      val (pR, pC) = (parentNames(reflect1), parentNames(classfile1))
+      println(s"[parents] reflect C parents=$pR  classfile C parents=$pC")
+      assert(pR.contains("Marker"), s"reflection should list transitive Marker: $pR")
+      assert(!pC.contains("Marker"), s"classfile (direct-only) should NOT list Marker yet: $pC")
+
+      // Consequence witness: reflection invalidates (hash changes when B drops Marker); the
+      // classfile path does not (C's bytes and member-less inherited set are identical across v1/v2).
+      val (hR1, hR2) = (reflect1.map(HashAPI(_)).sum, reflect2.map(HashAPI(_)).sum)
+      val (hC1, hC2) = (classfile1.map(HashAPI(_)).sum, classfile2.map(HashAPI(_)).sum)
+      println(s"[hash] reflect $hR1 -> $hR2 (changed=${hR1 != hR2}); " +
+        s"classfile $hC1 -> $hC2 (changed=${hC1 != hC2})")
+      assert(hR1 != hR2, "reflection hash must change when B drops `implements Marker`")
+      assert(
+        hC1 == hC2,
+        "BUG #1 witness: classfile hash does NOT change on the transitive-supertype change " +
+          s"(under-invalidation) — got $hC1 vs $hC2"
+      )
+    }
+  }
 }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -283,4 +283,80 @@ class DifferentialApiSpecification extends UnitSpec {
       )
     }
   }
+
+  // Deviation #2 (fixed): ClassfileToAPI now reads RuntimeVisible/InvisibleParameterAnnotations and
+  // folds them into the method's synthetic annotation, so a parameter-annotation-only change changes
+  // its hash — matching reflection (which carries them on the parameter type via api.Annotated). Was
+  // a green known-bug witness before the fix; now asserts both paths invalidate.
+  it should "detect a parameter-annotation change, matching reflection" in {
+    IO.withTemporaryDirectory { temp =>
+      val pa =
+        "import java.lang.annotation.*;\n" +
+          "@Retention(RetentionPolicy.RUNTIME) @Target(ElementType.PARAMETER) @interface PA {}\n"
+      val v1 = pa + "public class C { public void m(@PA String x) {} }"
+      val v2 = pa + "public class C { public void m(String x) {} }"
+      val (reflect1, classfile1) = buildApis(temp, 110, "C", v1)
+      val (reflect2, classfile2) = buildApis(temp, 111, "C", v2)
+      val (hR1, hR2) = (reflect1.map(HashAPI(_)).sum, reflect2.map(HashAPI(_)).sum)
+      val (hC1, hC2) = (classfile1.map(HashAPI(_)).sum, classfile2.map(HashAPI(_)).sum)
+      println(s"[param-anno hash] reflect changed=${hR1 != hR2}; classfile changed=${hC1 != hC2}")
+      assert(hR1 != hR2, "reflection hash must change when the parameter annotation is removed")
+      assert(
+        hC1 != hC2,
+        s"classfile hash must now change on a param-annotation change — $hC1 vs $hC2"
+      )
+    }
+  }
+
+  // The names of classes `process` reports as having a `main`, from each path.
+  private def mainClasses(temp: File, idx: Int, names: Seq[(String, String)], query: String) = {
+    val dir = new File(temp, s"m$idx")
+    dir.mkdir()
+    val srcs = names.map {
+      case (n, src) =>
+        val f = new File(dir, s"$n.java"); IO.write(f, src); f
+    }
+    JavaCompilerForUnitTesting.compileJava(srcs, dir, Seq.empty)
+    val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+    val resolve: String => Option[ClassFile] = bn => {
+      val res = bn.replace('.', '/') + ".class"
+      Option(loader.getResource(res))
+        .orElse(Option(ClassLoader.getSystemResource(res)))
+        .flatMap(u =>
+          try Some(Parser(u, Logger.Null))
+          catch { case _: Throwable => None }
+        )
+    }
+    val reflectMains = ClassToAPI.process(Seq(loader.loadClass(query)))._2
+    val cf = Parser(new File(dir, s"$query.class").toPath, Logger.Null)
+    val classfileMains = ClassfileToAPI.process(Seq(query -> cf), resolve)._2
+    (reflectMains, classfileMains)
+  }
+
+  // Deviation #3 (fixed): ClassfileToAPI.hasMain now also checks the inherited (superclass-chain)
+  // public static main, mirroring ClassToAPI's use of c.getMethods, so a subclass that inherits
+  // `main` is reported as a main class. Was a green known-bug witness before the fix; now asserts
+  // agreement with reflection.
+  it should "report an inherited main, matching reflection" in {
+    IO.withTemporaryDirectory { temp =>
+      val (reflectMains, classfileMains) = mainClasses(
+        temp,
+        0,
+        Seq(
+          "A" -> "public class A { public static void main(String[] a) {} }",
+          "B" -> "public class B extends A {}"
+        ),
+        query = "B"
+      )
+      println(s"[main] reflect=$reflectMains classfile=$classfileMains")
+      assert(
+        reflectMains.contains("B"),
+        s"reflection should report inherited main on B: $reflectMains"
+      )
+      assert(
+        classfileMains.contains("B"),
+        s"classfile should now report inherited main on B: $classfileMains"
+      )
+    }
+  }
 }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -359,4 +359,40 @@ class DifferentialApiSpecification extends UnitSpec {
       )
     }
   }
+
+  // Deviation #4 (fixed): reflection's topLevel is `getEnclosingClass == null`, false for member,
+  // local, AND anonymous classes. ClassfileToAPI now marks a class non-top-level on the mere presence
+  // of an InnerClasses self entry (no longer requiring a non-empty outer), so anonymous/local classes
+  // — whose self entry has outer index 0 — agree with reflection. Was a green known-bug witness
+  // before the fix.
+  it should "mark an anonymous class as non-top-level, matching reflection" in {
+    IO.withTemporaryDirectory { temp =>
+      val dir = new File(temp, "d4")
+      dir.mkdir()
+      val src = new File(dir, "Outer.java")
+      IO.write(src, "public class Outer { Runnable r = new Runnable() { public void run() {} }; }")
+      JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+      val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+      val resolve: String => Option[ClassFile] = bn => {
+        val res = bn.replace('.', '/') + ".class"
+        Option(loader.getResource(res))
+          .orElse(Option(ClassLoader.getSystemResource(res)))
+          .flatMap(u =>
+            try Some(Parser(u, Logger.Null))
+            catch { case _: Throwable => None }
+          )
+      }
+      val binary = "Outer$1" // the anonymous Runnable
+      val reflect = ClassToAPI.process(Seq(loader.loadClass(binary)))._1.filter(_.name == binary)
+      val cf = Parser(new File(dir, binary + ".class").toPath, Logger.Null)
+      val classfile = ClassfileToAPI.process(Seq(binary -> cf), resolve)._1.filter(_.name == binary)
+      val (rTop, cTop) = (reflect.map(_.topLevel).toSet, classfile.map(_.topLevel).toSet)
+      println(s"[topLevel] reflect=$rTop classfile=$cTop")
+      assert(rTop == Set(false), s"reflection: anon class is not top-level: $rTop")
+      assert(
+        cTop == rTop,
+        s"classfile topLevel must now match reflection — reflect=$rTop classfile=$cTop"
+      )
+    }
+  }
 }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/DifferentialApiSpecification.scala
@@ -251,16 +251,13 @@ class DifferentialApiSpecification extends UnitSpec {
   private def parentNames(apis: Seq[ClassLike]): Set[String] =
     apis.flatMap(_.structure.parents.toSeq.flatMap(parentSimpleName)).toSet
 
-  // KNOWN-BUG WITNESS (deviation #1): ClassToAPI lists the *transitive* supertype closure in a
-  // class's `parents` (ClassToAPI.allSuperTypes), whereas ClassfileToAPI lists only the *direct*
-  // supertypes (ClassfileToAPI.classLikes: superclass +: interfaces). So a subtyping relationship
-  // that `C` holds only through an intermediate `B` is invisible to the classfile path. With a
-  // member-less marker interface there is nothing for collectInherited to surface either, so C's
-  // classfile API — and thus its hash — does not change when B stops implementing the marker, even
-  // though C is no longer a Marker. Reflection's hash does change. This pins that gap empirically;
-  // once #1 is fixed (walk the transitive closure in classLikes), the two classfile hashes below
-  // will differ and this test should be updated to assert agreement with reflection.
-  it should "(known bug #1) miss a transitive-supertype change that reflection catches" in {
+  // Deviation #1 (fixed): ClassfileToAPI now lists the *transitive* supertype closure in `parents`
+  // (ClassfileToAPI.collectParents), matching ClassToAPI.allSuperTypes — not just the direct
+  // supertypes. So a subtyping relationship `C` holds only through an intermediate `B` (here a
+  // member-less marker interface that `B` stops implementing) changes C's API on both paths, and the
+  // classfile path no longer under-invalidates C's dependents. This was a green known-bug witness
+  // before the fix; it now asserts agreement with reflection.
+  it should "model the transitive supertype closure in parents, matching reflection" in {
     IO.withTemporaryDirectory { temp =>
       // v1: C -> B -> Marker (C is transitively a Marker).  v2: B no longer implements Marker.
       val v1 = "interface Marker {} class B implements Marker {} public class C extends B {}"
@@ -268,24 +265,21 @@ class DifferentialApiSpecification extends UnitSpec {
       val (reflect1, classfile1) = buildApis(temp, 100, "C", v1)
       val (reflect2, classfile2) = buildApis(temp, 101, "C", v2)
 
-      // Structural witness: reflection's parents for C include the transitive Marker; classfile's
-      // direct-only parents do not.
+      // Structural: both paths list the transitive Marker among C's parents, and agree.
       val (pR, pC) = (parentNames(reflect1), parentNames(classfile1))
       println(s"[parents] reflect C parents=$pR  classfile C parents=$pC")
-      assert(pR.contains("Marker"), s"reflection should list transitive Marker: $pR")
-      assert(!pC.contains("Marker"), s"classfile (direct-only) should NOT list Marker yet: $pC")
+      assert(pC.contains("Marker"), s"classfile should now list transitive Marker: $pC")
+      assert(pR == pC, s"parents should match reflection — reflect=$pR classfile=$pC")
 
-      // Consequence witness: reflection invalidates (hash changes when B drops Marker); the
-      // classfile path does not (C's bytes and member-less inherited set are identical across v1/v2).
+      // Consequence: both paths invalidate (hash changes when B drops `implements Marker`).
       val (hR1, hR2) = (reflect1.map(HashAPI(_)).sum, reflect2.map(HashAPI(_)).sum)
       val (hC1, hC2) = (classfile1.map(HashAPI(_)).sum, classfile2.map(HashAPI(_)).sum)
       println(s"[hash] reflect $hR1 -> $hR2 (changed=${hR1 != hR2}); " +
         s"classfile $hC1 -> $hC2 (changed=${hC1 != hC2})")
       assert(hR1 != hR2, "reflection hash must change when B drops `implements Marker`")
       assert(
-        hC1 == hC2,
-        "BUG #1 witness: classfile hash does NOT change on the transitive-supertype change " +
-          s"(under-invalidation) — got $hC1 vs $hC2"
+        hC1 != hC2,
+        s"classfile hash must now change on the transitive-supertype change — got $hC1 vs $hC2"
       )
     }
   }

--- a/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/FBoundStressSpecification.scala
+++ b/internal/zinc-apiinfo/src/test/scala/sbt/internal/inc/FBoundStressSpecification.scala
@@ -1,0 +1,128 @@
+/*
+ * Zinc - The incremental compiler for Scala.
+ * Copyright Scala Center, Lightbend, and Mark Harrah
+ *
+ * Licensed under Apache License 2.0
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package sbt
+package internal
+package inc
+
+import java.io.File
+import java.net.URLClassLoader
+import scala.concurrent.{ Await, Future }
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration._
+import sbt.internal.inc.classfile.{ ClassFile, JavaCompilerForUnitTesting, Parser }
+import sbt.io.IO
+import sbt.util.Logger
+import xsbt.api.HashAPI
+import xsbti.api.ClassLike
+
+/**
+ * Regression guard for the classfile-based Java API path against pathological generic signatures:
+ * the `f-bound-stress-test` corpus (deep and mutually recursive F-bounds, `L0 <-> Mirror` signature
+ * cycles, covariant bridges, nested generic inners, enum anonymous classes). The reflected `Type`
+ * graph for these is genuinely cyclic, so any extractor that expands a type variable into its bound,
+ * or chases method-return signatures, loops forever unless it stops at the variable. [[ClassfileToAPI]]
+ * is structurally safe (a `SigVar` maps to a by-name `ParameterRef`, never its bound; `collectInherited`
+ * carries a visited-set), and this test pins that: extraction must terminate, hash deterministically,
+ * and agree with reflection on declared/inherited member names.
+ */
+class FBoundStressSpecification extends UnitSpec {
+
+  // The corpus is maintained standalone in f-bound-stress-test; a copy lives in test resources so the
+  // guard runs hermetically. One multi-type .java file (one public type, the rest package-private).
+  private def corpusSource: String = {
+    val url = getClass.getClassLoader.getResource("fbound/FBoundedStress.java")
+    assert(url != null, "fbound/FBoundedStress.java missing from test resources")
+    IO.readStream(url.openStream())
+  }
+
+  // Compile the whole corpus once and return (output dir, every compiled class as name -> ClassFile).
+  private def compileCorpus(temp: File): (File, Seq[(String, ClassFile)]) = {
+    val dir = new File(temp, "classes")
+    dir.mkdir()
+    val src = new File(temp, "FBoundedStress.java")
+    IO.write(src, corpusSource)
+    JavaCompilerForUnitTesting.compileJava(Seq(src), dir, Seq.empty)
+    val classes = (dir.listFiles().toSeq.filter(_.getName.endsWith(".class"))).map { f =>
+      val cf = Parser(f.toPath, Logger.Null)
+      cf.className -> cf
+    }
+    assert(classes.sizeIs > 20, s"expected the full corpus to compile, got ${classes.map(_._1)}")
+    (dir, classes)
+  }
+
+  // Byte-only parent resolver (no class loading), exactly as production uses under classfileJavaApi.
+  private def byteResolver(dir: File): String => Option[ClassFile] = binaryName => {
+    val res = binaryName.replace('.', '/') + ".class"
+    val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+    Option(loader.getResource(res))
+      .orElse(Option(ClassLoader.getSystemResource(res)))
+      .flatMap(u =>
+        try Some(Parser(u, Logger.Null))
+        catch { case _: Throwable => None }
+      )
+  }
+
+  "ClassfileToAPI on the F-bound stress corpus" should "terminate and hash deterministically" in {
+    IO.withTemporaryDirectory { temp =>
+      val (dir, classes) = compileCorpus(temp)
+      val resolve = byteResolver(dir)
+
+      // A non-terminating walk would hang the suite; bound it so a cycle bug surfaces as a failure.
+      def hashAll(): Int =
+        Await.result(
+          Future(ClassfileToAPI.process(classes, resolve)._1.map(HashAPI(_)).sum),
+          30.seconds
+        )
+
+      val h1 = hashAll()
+      val h2 = hashAll()
+      assert(h1 == h2, "hash must be deterministic across runs over cyclic F-bound signatures")
+    }
+  }
+
+  it should "agree with ClassToAPI (reflection) on declared and inherited member names" in {
+    IO.withTemporaryDirectory { temp =>
+      val (dir, classes) = compileCorpus(temp)
+      val resolve = byteResolver(dir)
+      val loader = new URLClassLoader(Array(dir.toURI.toURL), null)
+
+      val classfileApis = ClassfileToAPI.process(classes, resolve)._1
+      def declared(c: ClassLike): Set[String] = c.structure.declared.map(_.name).toSet
+      def inherited(c: ClassLike): Set[String] = c.structure.inherited.map(_.name).toSet
+
+      val failures = scala.collection.mutable.ListBuffer.empty[String]
+      for ((binaryName, _) <- classes) {
+        // Reflection keys by canonical name; the classfile API does too. Skip anything reflection
+        // can't model cleanly (anonymous classes have no canonical name) to keep the comparison fair.
+        val loaded =
+          try Some(loader.loadClass(binaryName))
+          catch { case _: Throwable => None }
+        loaded.filter(_.getCanonicalName != null).foreach { cls =>
+          val name = cls.getCanonicalName
+          val reflect = ClassToAPI.process(Seq(cls))._1.filter(_.name == name)
+          val classfile = classfileApis.filter(_.name == name)
+          if (reflect.nonEmpty && classfile.nonEmpty) {
+            val dR = reflect.flatMap(declared).toSet
+            val dC = classfile.flatMap(declared).toSet
+            val iR = reflect.flatMap(inherited).toSet
+            val iC = classfile.flatMap(inherited).toSet
+            if (dR != dC)
+              failures += s"$name declared: onlyReflect=${dR -- dC} onlyClassfile=${dC -- dR}"
+            if (iR != iC)
+              failures += s"$name inherited: onlyReflect=${iR -- iC} onlyClassfile=${iC -- iR}"
+          }
+        }
+      }
+      assert(failures.isEmpty, "divergences from reflection:\n" + failures.mkString("\n"))
+    }
+  }
+}

--- a/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
+++ b/internal/zinc-classfile/src/main/scala/sbt/internal/inc/classfile/JavaAnalyze.scala
@@ -254,7 +254,13 @@ private[sbt] object JavaAnalyze {
         .toSeq
       // Best-effort: never let classfile-based API extraction fail a compile that would otherwise
       // succeed (these classes already couldn't be loaded), matching load()/loadInnerClass.
-      if (unloadableNamed.nonEmpty) trapAndLog(log)(readClassfileAPI(source, unloadableNamed))
+      // Exception: under classfileApiOnly the classfile path is the *primary* one for every class,
+      // so a failure there is a real regression, not a tolerable gap. -Dzinc.classfileJavaApi.strict
+      // makes it propagate (the scripted CI matrix sets it) so such breakage fails the build.
+      if (unloadableNamed.nonEmpty) {
+        if (classfileApiOnly && strictClassfileApi) readClassfileAPI(source, unloadableNamed)
+        else trapAndLog(log)(readClassfileAPI(source, unloadableNamed))
+      }
     }
   }
 
@@ -303,6 +309,12 @@ private[sbt] object JavaAnalyze {
       }
     }
   }
+
+  // Test/CI affordance: make classfile-API extraction failures fatal under classfileApiOnly so the
+  // scripted matrix (CONTRIBUTING.md) catches crashes in that path instead of silently swallowing
+  // them. Off in production, where the path stays best-effort.
+  private def strictClassfileApi: Boolean =
+    java.lang.Boolean.getBoolean("zinc.classfileJavaApi.strict")
 
   private def trapAndLog(log: Logger)(execute: => Unit): Unit = {
     try {

--- a/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
+++ b/internal/zinc-scripted/src/test/scala/sbt/internal/inc/IncHandler.scala
@@ -358,10 +358,16 @@ case class ProjectStructure(
         xsbti.compile.TransactionalManagerType
           .of((targetDir / "classes.bak").toFile, sbt.util.Logger.Null)
       )
+    // -Dzinc.scripted.classfileJavaApi=true|false forces the classfile-based Java API path for the
+    // whole scripted run (the CI matrix runs the suite both ways); absent, the per-test value stands.
+    val classfileJavaApi = Option(System.getProperty("zinc.scripted.classfileJavaApi"))
+      .map(_.toBoolean)
+      .getOrElse(incOptions0.classfileJavaApi())
     val incO =
       incOptions0
         .withClassfileManagerType(transactional)
         .withStoreApis(storeApis)
+        .withClassfileJavaApi(classfileJavaApi)
     (incO, sco)
   }
   val exportPipelining = incOptions.pipelining


### PR DESCRIPTION
## Review of [#1730](https://github.com/sbt/zinc/pull/1730) (classfile-based Java API): findings + hardening

I went through the classfile extraction path on top of [#1730](https://github.com/sbt/zinc/pull/1730) and audited it against the reflection path (`ClassToAPI`) member-by-member. The method was a differential one: for each aspect of the `ClassLike`, pin the divergence with a witness test, confirm it red→green, then fix. Four deviations surfaced; three were genuine under-invalidation.

**Correctness fixes** (each has a test that was a green known-bug witness before the fix and now asserts agreement with reflection):

- **`parents` was direct-only, not transitive.** `ClassToAPI` lists the full supertype closure (`allSuperTypes`); the classfile path listed only direct supertypes. So a subtyping relationship held only through an intermediate — e.g. a member-less marker interface a superclass stops implementing — didn't change the class's API, and dependents weren't recompiled even though the class was no longer a subtype. This is the one that actually matters. Fixed with a cycle-safe transitive walk over parent classfiles; also drops the prior "interface parents include `Object`" wart.
- **Parameter annotations were dropped.** `RuntimeVisible/InvisibleParameterAnnotations` weren't read, so a param-annotation-only change didn't invalidate. Now folded into the method's synthetic annotation.
- **Inherited `main` wasn't detected** (own methods only vs. reflection's `getMethods`). Now walks the superclass chain.
- **Local/anonymous classes were marked `topLevel`** (their InnerClasses self-entry has an empty outer). Cosmetic, fixed for parity.

**Test + CI infrastructure:**

- Folded our `f-bound-stress-test` corpus in as a regression guard — the cyclic F-bound signatures are exactly what breaks a naive extractor; it pins termination, determinism, and member agreement with reflection.
- Added a scripted matrix that runs the suite with `classfileJavaApi` on. A mutation check showed this had **no teeth as first written**: `readClassfileAPI` is wrapped in `trapAndLog`, so an injected crash was swallowed and every Java scripted test still passed; and fine-grained API-hash regressions don't surface through scripted at all (cross-unit invalidation there is dominated by source changes and inheritance). So I added `-Dzinc.classfileJavaApi.strict` to make the classfile path fail loud under `classfileApiOnly`, and lean on the unit/differential tests for fine-grained correctness. Documented the split in `CONTRIBUTING.md`.

**Caveat on the CI changes:** I'm not a primary maintainer — the new matrix job and the switch to server-free sbt invocations (`--server -Dsbt.server.autostart=false`, to stop a reused background server carrying stale classes/`-D` between the benchmark jobs' two invocations) should get a maintainer's eye before merging. The correctness fixes and tests stand on their own regardless.

**Intentional differences** (documented in the `ClassfileToAPI` scaladoc, not bugs): the classfile path captures CLASS-retention annotations that reflection can't see — the right criterion for invalidation is compile-time observability by a dependent, not runtime visibility, and javac exposes those via `javax.lang.model`, so this is closer to correct, at the cost of mild over-invalidation. And the nested-class reference in an outer's declared members is abbreviated, but the nested class's own entry carries the detail.
